### PR TITLE
fix(auto-add-contributors): add check to prevent duplicate pull requests on contributor change

### DIFF
--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -26,6 +26,8 @@ jobs:
             echo "Contributors pull request already exists. Exiting."
             exit 0
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Contribute List
         uses: akhilmhdh/contributors-readme-action@1ff4c56187458b34cd602aee93e897344ce34bfc # v2.3.10

--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -17,15 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Get PR title from YAML
-        id: get_pr_title
-        run: |
-          pr_title=$(docker run --rm -v "${PWD}":/workdir mikefarah/yq e '.jobs."contrib-readme-job".steps[] | select(.name == "Contribute List") | .with.pr_title_on_protected' .github/workflows/auto-update-contributors.yml)
-          echo "pr_title=$pr_title" >> $GITHUB_ENV
-
       - name: Check for existing open contributors pull request
         id: check_pr
         run: |
+          pr_title="docs(contributor): contributors readme action update"
           existing_pr=$(gh pr list --state open --search "$pr_title" --json title --jq '.[].title')
           if [[ "$existing_pr" == "$pr_title" ]]; then
             echo "Contributors pull request already exists. Exiting."

--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Check for existing open contributors pull request
         id: check_pr
         run: |

--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -17,8 +17,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Get PR title from YAML
+        id: get_pr_title
+        run: |
+          pr_title=$(docker run --rm -v "${PWD}":/workdir mikefarah/yq e '.jobs."contrib-readme-job".steps[] | select(.name == "Contribute List") | .with.pr_title_on_protected' .github/workflows/auto-update-contributors.yml)
+          echo "pr_title=$pr_title" >> $GITHUB_ENV
+
+      - name: Check for existing open contributors pull request
+        id: check_pr
+        run: |
+          existing_pr=$(gh pr list --state open --search "$pr_title" --json title --jq '.[].title')
+          if [[ "$existing_pr" == "$pr_title" ]]; then
+            echo "Contributors pull request already exists. Exiting."
+            exit 0
+          fi
+
       - name: Contribute List
         uses: akhilmhdh/contributors-readme-action@1ff4c56187458b34cd602aee93e897344ce34bfc # v2.3.10
+        with:
+          pr_title_on_protected: docs(contributor): contributors readme action update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           use_username: true

--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Contribute List
         uses: akhilmhdh/contributors-readme-action@1ff4c56187458b34cd602aee93e897344ce34bfc # v2.3.10
         with:
-          pr_title_on_protected: docs(contributor): contributors readme action update
+          pr_title_on_protected: 'docs(contributor): contributors readme action update'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           use_username: true

--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -36,6 +36,7 @@ jobs:
         uses: akhilmhdh/contributors-readme-action@1ff4c56187458b34cd602aee93e897344ce34bfc # v2.3.10
         with:
           pr_title_on_protected: 'docs(contributor): contributors readme action update'
+          commit_message: 'docs(contributor): contributors readme action update'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           use_username: true


### PR DESCRIPTION
Related to #75

Add a step to check for existing open pull requests using GitHub CLI before creating a new one.

- **Check for existing open contributors pull request**: Add a step to check for existing open contributors pull requests using GitHub CLI and exit if one already exists.
- **Contribute List**: Add `pr_title_on_protected` and `commit_message` input to the `Contribute List` step to ensure the PR title is deterministic.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DelineaXPM/github-workflows/issues/75?shareId=32474525-2ba2-4604-9f55-30d8b69cb2d4).