### PR TITLE
fix(auto-add-contributors): ensure auto-add-contributors doesn't create duplicate pull requests

### DIFF
--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -29,12 +29,16 @@ jobs:
           if [[ -n "$existing_pr" ]]; then
             echo "Contributors pull request already exists. Exiting."
             echo "::warning::bypassed per open pull request already exists"
+            echo "OpenContributorRequestAlreadyExists=true" >> $GITHUB_ENV
             exit 0
+          else
+            echo "OpenContributorRequestAlreadyExists=false" >> $GITHUB_ENV
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Contribute List
+        if: env.OpenContributorRequestAlreadyExists == 'false'
         uses: akhilmhdh/contributors-readme-action@1ff4c56187458b34cd602aee93e897344ce34bfc # v2.3.10
         with:
           pr_title_on_protected: 'docs(contributor): contributors readme action update'

--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -26,7 +26,7 @@ jobs:
           pr_title="docs(contributor): contributors readme action update"
           existing_pr=$(gh pr list --state open --search "$pr_title" --json title --jq '.[].title')
           echo "::debug::List of open pull requests: $(gh pr list --state open --json title --jq '.[].title')"
-          if [[ "$existing_pr" == "$pr_title" ]]; then
+          if [[ -n "$existing_pr" ]]; then
             echo "Contributors pull request already exists. Exiting."
             echo "::warning::bypassed per open pull request already exists"
             exit 0

--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -25,8 +25,10 @@ jobs:
         run: |
           pr_title="docs(contributor): contributors readme action update"
           existing_pr=$(gh pr list --state open --search "$pr_title" --json title --jq '.[].title')
+          echo "::debug::List of open pull requests: $existing_pr"
           if [[ "$existing_pr" == "$pr_title" ]]; then
             echo "Contributors pull request already exists. Exiting."
+            echo "::warning::bypassed per open pull request already exists"
             exit 0
           fi
         env:

--- a/.github/workflows/auto-update-contributors.yml
+++ b/.github/workflows/auto-update-contributors.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           pr_title="docs(contributor): contributors readme action update"
           existing_pr=$(gh pr list --state open --search "$pr_title" --json title --jq '.[].title')
-          echo "::debug::List of open pull requests: $existing_pr"
+          echo "::debug::List of open pull requests: $(gh pr list --state open --json title --jq '.[].title')"
           if [[ "$existing_pr" == "$pr_title" ]]; then
             echo "Contributors pull request already exists. Exiting."
             echo "::warning::bypassed per open pull request already exists"


### PR DESCRIPTION
Related to #75

Update auto-add-contributors action to prevent duplicate pull requests.

* Add a step to check for existing open pull requests with the title "docs(contributor): contributors readme action update" using the GitHub CLI command `gh pr list`.
* Output a debug message listing the open pull requests for troubleshooting purposes.
* Output a warning message using the special warning syntax for GitHub if an existing open pull request is found.
* Exit the action without creating a new pull request if an existing one is found.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DelineaXPM/github-workflows/issues/75?shareId=bb94dd48-6c80-432f-87ec-510292d80091).